### PR TITLE
add unit test

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, App};
+
+    #[actix_rt::test]
+    async fn test_index() {
+        let mut app = test::init_service(App::new().service(index)).await;
+        let req = test::TestRequest::get().uri("/").to_request();
+        let resp = test::call_service(&mut app, req).await;
+
+        assert!(resp.status().is_success());
+    }
+}


### PR DESCRIPTION
This PR is intended to add unit test to our project.
The test function test_index calls the index function through the test client actix_web::test::TestRequest and then checks if the response is an HTTP status code 200. The test function is marked with the #[actix_rt::test] attribute to indicate that it should be run as a unit test.