### PR TITLE
Read HTTP host and port from environment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,14 @@ async fn index() -> HttpResponse {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    let host = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = std::env::var("PORT").unwrap_or_else(|_| "8000".to_string());
+    let bind_addr = format!("{}:{}", host, port);
+
     let server = actix_web::HttpServer::new(|| {
         actix_web::App::new()
             .service(index)
     });
 
-    server.bind("127.0.0.1:8000")?.run().await
+    server.bind(bind_addr)?.run().await
 }


### PR DESCRIPTION
## Summary
- pull HOST and PORT from environment variables with fallbacks

## Testing
- `cargo test -q` *(fails: could not fetch index)*
