### PR TITLE
Add health check endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ edition = "2021"
 [dependencies]
 actix-web = "3.3.2"
 tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+
+[[test]]
+name = "api_tests"
+path = "src/test.rs"

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,0 +1,6 @@
+use actix_web::{HttpResponse, Responder};
+use serde_json::json;
+
+pub async fn health_check() -> impl Responder {
+    HttpResponse::Ok().json(json!({ "status": "ok" }))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use actix_web::{HttpResponse, get, web};
 
+mod handlers;
+
 #[get("/")]
 async fn index() -> HttpResponse {
     HttpResponse::Ok().finish()
@@ -14,6 +16,7 @@ async fn main() -> std::io::Result<()> {
     let server = actix_web::HttpServer::new(|| {
         actix_web::App::new()
             .service(index)
+            .route("/health", web::get().to(handlers::health_check))
     });
 
     server.bind(bind_addr)?.run().await

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,14 +1,30 @@
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use actix_web::{test, App};
+#[path = "main.rs"]
+mod main;
+#[path = "handlers.rs"]
+mod handlers;
 
-    #[actix_rt::test]
-    async fn test_index() {
-        let mut app = test::init_service(App::new().service(index)).await;
-        let req = test::TestRequest::get().uri("/").to_request();
-        let resp = test::call_service(&mut app, req).await;
+use actix_web::{test, web, App};
 
-        assert!(resp.status().is_success());
-    }
+#[actix_rt::test]
+async fn test_index() {
+    let mut app = App::new().service(main::index);
+    let mut app = test::init_service(app).await;
+    let req = test::TestRequest::get().uri("/").to_request();
+    let resp = test::call_service(&mut app, req).await;
+
+    assert!(resp.status().is_success());
 }
+
+#[actix_rt::test]
+async fn test_health_check() {
+    let mut app =
+        App::new().route("/health", web::get().to(handlers::health_check));
+    let mut app = test::init_service(app).await;
+    let req = test::TestRequest::get().uri("/health").to_request();
+    let resp = test::call_service(&mut app, req).await;
+
+    assert!(resp.status().is_success());
+    let body = test::read_body(resp).await;
+    assert_eq!(body, r#"{"status":"ok"}"#);
+}
+


### PR DESCRIPTION
## Summary
- add `handlers` module with `health_check` function
- register `/health` route
- cover new endpoint with tests

## Testing
- `cargo test --quiet` *(fails: failed to get `actix-web` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68502bf77e688324b973ad8cd7d22510