### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1 AS builder
+WORKDIR /usr/src/app
+COPY . .
+RUN cargo build --release
+
+FROM debian:buster-slim AS runtime
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app/target/release/bcode-seed-rust-api ./
+ENV HOST=0.0.0.0
+EXPOSE 8000
+CMD ["./bcode-seed-rust-api"]

--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ After the server is running you can hit the root endpoint:
 curl -i http://127.0.0.1:8000/
 ```
 
-## Docker (optional)
+## Docker
 
-There is no Dockerfile in this repository, but you can run the app with a Rust
-Docker image if you prefer:
+Build the image:
 
 ```bash
-docker run --rm -it -p 8000:8000 -v "$PWD":/usr/src/app -w /usr/src/app rust:latest cargo run
+docker build -t bcode-seed-rust-api .
 ```
+
+Run the container:
+
+```bash
+docker run --rm -p 8000:8000 bcode-seed-rust-api
+```
+


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile to build the Rust API
- document Docker build and run steps in the README

## Testing
- `cargo test` *(fails: crates.io unreachable)*
