### PR TITLE
Upgrade Actix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "3.3.2"
+actix-web = "4"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ mod handlers;
 
 use actix_web::{test, web, App};
 
-#[actix_rt::test]
+#[actix_web::test]
 async fn test_index() {
     let mut app = App::new().service(main::index);
     let mut app = test::init_service(app).await;
@@ -15,7 +15,7 @@ async fn test_index() {
     assert!(resp.status().is_success());
 }
 
-#[actix_rt::test]
+#[actix_web::test]
 async fn test_health_check() {
     let mut app =
         App::new().route("/health", web::get().to(handlers::health_check));


### PR DESCRIPTION
## Summary
- bump to actix-web v4
- update test macros for new API

## Testing
- `cargo test --quiet` *(fails: failed to download actix-web)*
